### PR TITLE
Дробление переводчика

### DIFF
--- a/MathSolver/RpnInstaller.cs
+++ b/MathSolver/RpnInstaller.cs
@@ -1,8 +1,11 @@
-﻿using Castle.MicroKernel.Registration;
+﻿using System.Collections.Generic;
+
+using Castle.MicroKernel.Registration;
 using Castle.MicroKernel.SubSystems.Configuration;
 using Castle.Windsor;
 
 using ReversePolishNotation;
+using ReversePolishNotation.Interpreters;
 
 namespace MathSolver
 {
@@ -13,6 +16,17 @@ namespace MathSolver
 			container.Register(
 				Component.For(typeof (ISplitter))
 				         .ImplementedBy(typeof (SimpleSplitter))
+				         .LifestyleSingleton(),
+
+				Component.For(typeof (IList<IRpnInterpreter>))
+				         .UsingFactoryMethod(
+					         () => new List<IRpnInterpreter>
+					         {
+						         new BasicOperatorsInterpreter(),
+								 new AdditionalOperatorsInterpreter(),
+								 new ParenthesesInterpreter(),
+								 new NumberInterpreter()
+					         })
 				         .LifestyleSingleton(),
 
 				Component.For(typeof (IRpnTranslator))

--- a/ReversePolishNotation/BasicOperators.cs
+++ b/ReversePolishNotation/BasicOperators.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ReversePolishNotation
+{
+	public static class BasicOperators
+	{
+		public static Func<double, double, double> Multiplication = (x, y) => x * y;
+		public static Func<double, double, double> Addition = (x, y) => x + y;
+		public static Func<double, double, double> Subtraction = (x, y) => x - y;
+		public static Func<double, double, double> Division = (x, y) => x / y;
+	}
+}

--- a/ReversePolishNotation/IRpnInterpreter.cs
+++ b/ReversePolishNotation/IRpnInterpreter.cs
@@ -1,0 +1,10 @@
+﻿
+using System.Collections.Generic;
+
+namespace ReversePolishNotation
+{
+	public interface IRpnInterpreter
+	{
+		bool Interpret(string element, Stack<Operator> stackOfOperators, IList<IRpnElement> rpnOutput);
+	}
+}

--- a/ReversePolishNotation/Interpreters/AdditionalOperatorsInterpreter.cs
+++ b/ReversePolishNotation/Interpreters/AdditionalOperatorsInterpreter.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace ReversePolishNotation.Interpreters
+{
+	public class AdditionalOperatorsInterpreter : BasicOperatorsInterpreter
+	{
+		public AdditionalOperatorsInterpreter()
+		{
+			Operators = new Dictionary<string, Operator>()
+			{
+				{">>", new Operator() { Priority = 5, RpnOperator = new RpnBinaryOperator((x, y) => (int)x >> (int)y) }},
+				{"<<", new Operator() { Priority = 5, RpnOperator = new RpnBinaryOperator((x, y) => (int)x << (int)y) }}
+			};
+		}
+	}
+}

--- a/ReversePolishNotation/Interpreters/BasicOperatorsInterpreter.cs
+++ b/ReversePolishNotation/Interpreters/BasicOperatorsInterpreter.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace ReversePolishNotation.Interpreters
+{
+	public class BasicOperatorsInterpreter : IRpnInterpreter
+	{
+		protected Dictionary<string, Operator> Operators;
+
+		public BasicOperatorsInterpreter()
+		{
+			Operators = new Dictionary<string, Operator>()
+			{
+				{"*", new Operator() {Priority = 2, RpnOperator = new RpnBinaryOperator(BasicOperators.Multiplication)}},
+				{"/", new Operator() {Priority = 2, RpnOperator = new RpnBinaryOperator(BasicOperators.Division)}},
+				{"+", new Operator() {Priority = 1, RpnOperator = new RpnBinaryOperator(BasicOperators.Addition)}},
+				{"-", new Operator() {Priority = 1, RpnOperator = new RpnBinaryOperator(BasicOperators.Subtraction)}}
+			};
+		}
+
+		public bool Interpret(string element, Stack<Operator> stackOfOperators, IList<IRpnElement> rpnOutput)
+		{
+			if (Operators.ContainsKey(element))
+			{
+				var oper = Operators[element];
+
+				while (stackOfOperators.Count != 0 &&
+					oper.Priority <= stackOfOperators.Peek().Priority)
+				{
+					rpnOutput.Add(stackOfOperators.Pop().RpnOperator);
+				}
+
+				stackOfOperators.Push(oper);
+				return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/ReversePolishNotation/Interpreters/NumberInterpreter.cs
+++ b/ReversePolishNotation/Interpreters/NumberInterpreter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace ReversePolishNotation.Interpreters
+{
+	public class NumberInterpreter : IRpnInterpreter
+	{
+		private const string RegexIsNumber = @"^[0-9]+\.?[0-9]*$";
+
+		public bool Interpret(string element, Stack<Operator> stackOfOperators, IList<IRpnElement> rpnOutput)
+		{
+			if (IsNumber(element))
+			{
+				rpnOutput.Add(new RpnNumber(Double.Parse(element, new NumberFormatInfo() { CurrencyDecimalSeparator = "." })));
+				return true;
+			}
+
+			return false;
+		}
+
+		private static bool IsNumber(string str)
+		{
+			return Regex.IsMatch(str, RegexIsNumber);
+		}
+	}
+}

--- a/ReversePolishNotation/Interpreters/ParenthesesInterpreter.cs
+++ b/ReversePolishNotation/Interpreters/ParenthesesInterpreter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ReversePolishNotation.Interpreters
+{
+	public class ParenthesesInterpreter : IRpnInterpreter
+	{
+		public bool Interpret(string element, Stack<Operator> stackOfOperators, IList<IRpnElement> rpnOutput)
+		{
+			if ("()".Contains(element))
+			{
+				if (element.Equals("("))
+					stackOfOperators.Push(new Operator() { Priority = 0 });
+				else
+				{
+					try
+					{
+						while (stackOfOperators.Peek().Priority != 0)
+						{
+							rpnOutput.Add(stackOfOperators.Pop().RpnOperator);
+						}
+						stackOfOperators.Pop();
+					}
+					catch (InvalidOperationException)
+					{
+						throw new Exception("Отсутствует открывающая скобка");
+					}
+				}
+				return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/ReversePolishNotation/Operator.cs
+++ b/ReversePolishNotation/Operator.cs
@@ -1,0 +1,9 @@
+﻿
+namespace ReversePolishNotation
+{
+	public struct Operator
+	{
+		public int Priority;
+		public IRpnElement RpnOperator;
+	}
+}

--- a/ReversePolishNotation/ReversePolishNotation.csproj
+++ b/ReversePolishNotation/ReversePolishNotation.csproj
@@ -41,8 +41,15 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Interpreters\AdditionalOperatorsInterpreter.cs" />
+    <Compile Include="BasicOperators.cs" />
+    <Compile Include="Interpreters\BasicOperatorsInterpreter.cs" />
     <Compile Include="IRpnElement.cs" />
+    <Compile Include="IRpnInterpreter.cs" />
     <Compile Include="ISplitter.cs" />
+    <Compile Include="Interpreters\NumberInterpreter.cs" />
+    <Compile Include="Operator.cs" />
+    <Compile Include="Interpreters\ParenthesesInterpreter.cs" />
     <Compile Include="RpnBinaryOperator.cs" />
     <Compile Include="RpnNumber.cs" />
     <Compile Include="RpnSolver.cs" />

--- a/ReversePolishNotation/RpnTranslator.cs
+++ b/ReversePolishNotation/RpnTranslator.cs
@@ -1,38 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace ReversePolishNotation
 {
 	public class RpnTranslator : IRpnTranslator
 	{
-		public static Func<double, double, double> Multiplication = (x, y) => x * y;
-		public static Func<double, double, double> Addition = (x, y) => x + y;
-		public static Func<double, double, double> Subtraction = (x, y) => x - y;
-		public static Func<double, double, double> Division = (x, y) => x / y;
-
 		private readonly ISplitter _splitter;
-
-		private const string _regexIsNumber = @"^[0-9]+\.?[0-9]*$";
-
-		private readonly Dictionary<string, Operator> _operators = new Dictionary<string, Operator>()
-		{
-			{">>", new Operator() {Priority = 5, RpnOperator = new RpnBinaryOperator((x, y) => (int)x >> (int)y)}},
-			{"<<", new Operator() {Priority = 5, RpnOperator = new RpnBinaryOperator((x, y) => (int)x << (int)y)}},
-
-			{"*", new Operator() {Priority = 2, RpnOperator = new RpnBinaryOperator(Multiplication)}},
-			{"/", new Operator() {Priority = 2, RpnOperator = new RpnBinaryOperator(Division)}},
-			{"+", new Operator() {Priority = 1, RpnOperator = new RpnBinaryOperator(Addition)}},
-			{"-", new Operator() {Priority = 1, RpnOperator = new RpnBinaryOperator(Subtraction)}}
-		};
+		private readonly IList<IRpnInterpreter> _interpreters;
 
 		#region Constructor
 
-		public RpnTranslator(ISplitter splitter)
+		public RpnTranslator(ISplitter splitter, IList<IRpnInterpreter> interpreters)
 		{
 			_splitter = splitter;
+			_interpreters = interpreters;
 		}
 
 		#endregion
@@ -44,46 +26,10 @@ namespace ReversePolishNotation
 
 			foreach (var element in _splitter.Split(expression))
 			{
-				if (_operators.ContainsKey(element))
-				{
-					var oper = _operators[element];
+				var wasProcessed = _interpreters.Any(interpreter => interpreter.Interpret(element, stackOfOperators, result));
 
-					while (stackOfOperators.Any() &&
-						oper.Priority <= stackOfOperators.Peek().Priority)
-					{
-						result.Add(stackOfOperators.Pop().RpnOperator);
-					}
-
-					stackOfOperators.Push(oper);
-				}
-				else if ("()".Contains(element))
-				{
-					if (element.Equals("("))
-						stackOfOperators.Push(new Operator() {Priority = 0});
-					else
-					{
-						try
-						{
-							while (stackOfOperators.Peek().Priority != 0)
-							{
-								result.Add(stackOfOperators.Pop().RpnOperator);
-							}
-							stackOfOperators.Pop();
-						}
-						catch (InvalidOperationException e)
-						{
-							throw new Exception("Отсутствует открывающая скобка");
-						}
-					}
-				}
-				else if (IsNumber(element))
-				{
-					result.Add(new RpnNumber(double.Parse(element, new NumberFormatInfo() { CurrencyDecimalSeparator = "." })));
-				}
-				else
-				{
+				if (!wasProcessed)
 					throw new Exception($"Неизвестный элемент выражения: {element}");
-				}
 			}
 
 			while (stackOfOperators.Any())
@@ -95,17 +41,6 @@ namespace ReversePolishNotation
 			}
 
 			return result;
-		}
-
-		private static bool IsNumber(string str)
-		{
-			return Regex.IsMatch(str, _regexIsNumber);
-		}
-
-		private struct Operator
-		{
-			public int Priority;
-			public IRpnElement RpnOperator;
 		}
 	}
 }

--- a/UnitTests/RpnTranslatorTests.cs
+++ b/UnitTests/RpnTranslatorTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using NUnit.Framework;
 
 using ReversePolishNotation;
+using ReversePolishNotation.Interpreters;
 
 namespace UnitTests
 {
@@ -85,11 +86,20 @@ namespace UnitTests
 
 		#endregion
 
+		private IList<IRpnInterpreter> GetInterpreters()
+		{
+			return new List<IRpnInterpreter>
+			{
+				new BasicOperatorsInterpreter(),
+				new ParenthesesInterpreter(),
+				new NumberInterpreter()
+			};
+		}
 
 		[Test]
 		public void Translate_Correct()
 		{
-			var translator = new RpnTranslator(SetupSplitter_Correct());
+			var translator = new RpnTranslator(SetupSplitter_Correct(), GetInterpreters());
 
 			CollectionAssert.AreEqual(
 				translator.Translate(expCorrect1),
@@ -98,8 +108,8 @@ namespace UnitTests
 					new RpnNumber(4),
 					new RpnNumber(2),
 					new RpnNumber(7),
-					new RpnBinaryOperator(RpnTranslator.Multiplication),
-					new RpnBinaryOperator(RpnTranslator.Addition)
+					new RpnBinaryOperator(BasicOperators.Multiplication),
+					new RpnBinaryOperator(BasicOperators.Addition)
 				});
 
 			CollectionAssert.AreEqual(
@@ -109,8 +119,8 @@ namespace UnitTests
 					new RpnNumber(3),
 					new RpnNumber(6),
 					new RpnNumber(2),
-					new RpnBinaryOperator(RpnTranslator.Subtraction),
-					new RpnBinaryOperator(RpnTranslator.Multiplication)
+					new RpnBinaryOperator(BasicOperators.Subtraction),
+					new RpnBinaryOperator(BasicOperators.Multiplication)
 				});
 
 			CollectionAssert.AreEqual(
@@ -120,15 +130,15 @@ namespace UnitTests
 					new RpnNumber(3),
 					new RpnNumber(1),
 					new RpnNumber(2),
-					new RpnBinaryOperator(RpnTranslator.Division),
-					new RpnBinaryOperator(RpnTranslator.Subtraction)
+					new RpnBinaryOperator(BasicOperators.Division),
+					new RpnBinaryOperator(BasicOperators.Subtraction)
 				});
 		}
 
 		[Test]
 		public void Translate_CorrectDecimal()
 		{
-			var translator = new RpnTranslator(SetupSplitter_CorrectDecimal());
+			var translator = new RpnTranslator(SetupSplitter_CorrectDecimal(), GetInterpreters());
 
 			CollectionAssert.AreEqual(
 				translator.Translate(expCorrectDecimal),
@@ -137,15 +147,15 @@ namespace UnitTests
 					new RpnNumber(3),
 					new RpnNumber(1.5),
 					new RpnNumber(2.8),
-					new RpnBinaryOperator(RpnTranslator.Division),
-					new RpnBinaryOperator(RpnTranslator.Subtraction)
+					new RpnBinaryOperator(BasicOperators.Division),
+					new RpnBinaryOperator(BasicOperators.Subtraction)
 				});
 		}
 
 		[Test]
 		public void Translate_IncorrectParentheses()
 		{	
-			var translator = new RpnTranslator(SetupSplitter_IncorrectParentheses());
+			var translator = new RpnTranslator(SetupSplitter_IncorrectParentheses(), GetInterpreters());
 
 			Assert.Throws<Exception>(() => translator.Translate(expIncorrectParentheses1));           // нет открывающей скобки
 			Assert.Throws<Exception>(() => translator.Translate(expIncorrectParentheses2));           // нет закрывающей скобки
@@ -154,7 +164,7 @@ namespace UnitTests
 		[Test]
 		public void Translate_IncorrectOperator()
 		{
-			var translator = new RpnTranslator(SetupSplitter_IncorrectOperator());
+			var translator = new RpnTranslator(SetupSplitter_IncorrectOperator(), GetInterpreters());
 			
 			Assert.Throws<Exception>(() => translator.Translate(expIncorrectOperator));           // неизвестный оператор
 		}


### PR DESCRIPTION
Проверки в RpnTranslator.Translate(string expression) разделены по различным классам *Interpreter.

Это позволяет более гибко настраивать RpnTranslator;
делает код более читабельным и понятным;
упрощает поддержку.
